### PR TITLE
Fixed - country name is not showing in shiny UI

### DIFF
--- a/rChartOECD/ui.R
+++ b/rChartOECD/ui.R
@@ -11,7 +11,7 @@ shinyUI(pageWithSidebar(
       selected = 2011),
     selectInput(inputId = "country",
       label = "Select country to compare years",
-      choices = sort(unique(dat2m$country)),
+      choices = sort(unique(as.character(dat2m$country))),
       selected = "Canada")
   ),
   


### PR DESCRIPTION
Hi Ramnath,

Thanks a lot for this tutorial. I've noticed that in your example Shiny UI doesn't shown country names anymore, which I guess was the case 2 years ago. I made a tiny change in the code to fix that. 

Was:
![screen shot 2015-02-13 at 15 01 24](https://cloud.githubusercontent.com/assets/533822/6189541/4f218f82-b393-11e4-9895-796c66fe919c.png)

Now:
![screen shot 2015-02-13 at 15 01 51](https://cloud.githubusercontent.com/assets/533822/6189535/3eb296c8-b393-11e4-97eb-48e628773ae4.png)

Regards,
Galiya
